### PR TITLE
feat(): update get release endpoint

### DIFF
--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -7,6 +7,6 @@ export class AppService {
   }
 
   getRelease(): string {
-    return 'Release 1.0.0';
+    return 'Release 2.0.0';
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: the new get release endpoint now return version 2.0.0. From now version < 2.0.0. were considered deprecated